### PR TITLE
international status parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 
 , "dependencies": {"underscore": "1.x.x"}
 , "devDependencies":
-  { "should":        "0.4.x"
+  { "should":        "1.2.x"
   , "mocha":         "0.x.x"
   , "coffee-script": "1.1.x"
   }

--- a/src/status.coffee
+++ b/src/status.coffee
@@ -21,4 +21,6 @@ S.Status = class Status
         continue
       file = line.substr 3
       type = line.substr 0,2
-      @files[file] = { type: type.trim(), staged: (line[0] != " " and line[0] != "?" ) , tracked: line[0] != "?"  }
+      @files[file] = { staged: (line[0] != " " and line[0] != "?" ) , tracked: line[0] != "?"  }
+      if type != "??"
+        @files[file].type = type.trim()

--- a/test/status.test.coffee
+++ b/test/status.test.coffee
@@ -4,38 +4,16 @@ git      = require '../src'
 Status   = require '../src/status'
 
 GIT_STATUS = """
-    # On branch master
-    # Changes to be committed:
-    #   (use "git reset HEAD <file>..." to unstage)
-    #
-    #       deleted:    crackers.txt
-    #       modified:   file.txt
-    #
-    # Changed but not updated:
-    #   (use "git add <file>..." to update what will be committed)
-    #   (use "git checkout -- <file>..." to discard changes in working directory)
-    #
-    #       modified:   cheese.txt
-    #
-    # Untracked files:
-    #   (use "git add <file>..." to include in what will be committed)
-    #
-    #       pickles.txt
+     M cheese.txt
+    D  crackers.txt
+    M  file.txt
+    ?? pickles.txt
   """
-GIT_STATUS_CLEAN = """
-    # On branch master
-    # nothing to commit (working directory clean)
-  """
+GIT_STATUS_CLEAN = ""
 GIT_STATUS_NOT_CLEAN = """
-    # On branch master
-    # Changes not staged for commit:
-    #   (use "git add ..." to update what will be committed)
-    #   (use "git checkout -- ..." to discard changes in working directory)
-    #
-    #   modified:   lib/index.js
-    #   modified:   npm-shrinkwrap.json
-    #   modified:   package.json
-    #
+    A  lib/index.js
+     M npm-shrinkwrap.json
+     M package.json
   """
 
 describe "Status", ->


### PR DESCRIPTION
hi, this patch parses git status independent from the LANG environment variable by using the "--porcelain" option
