### PR TITLE
Added pull only function

### DIFF
--- a/src/repo.coffee
+++ b/src/repo.coffee
@@ -418,8 +418,8 @@ module.exports = class Repo
 
     @status (err, status) =>
       return callback err if err
-      @git "pull", {}, [remote, branch], (err) =>
-        return callback err if err
+      @git "pull", {}, [remote, branch], (err, stdout, stderr) =>
+        return callback stderr if err
         return callback null
     
   # Internal: Parse the list of files from `git ls-files`


### PR DESCRIPTION
Sync is not useful if you have a simple clone of a read only repo
