### PR TITLE
Add missing status.type cases to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,18 @@ the file is staged, tracked, etc.
 
 Each file has the following properties:
 
-  * `type`    - "A" for added, "M" for modified, "D" for deleted.
+  * `type` which translates to:
+
+| _type_   | index     | working tree |
+| :---     | :-------: | :-----------:|
+| `A `     | added     | -            |
+| `M `     | modified  | -            |
+| `D `     | deleted   | -            |
+| `AM`     | added     | modified     |
+| `MM`     | modified  | modified     |
+| `AD`     | staged    | deleted      |
+| `MD`     | modified  | deleted      |
+
   * `staged`  - `Boolean`
   * `tracked` - `Boolean`
 


### PR DESCRIPTION
It might be wise to acknowledge those cases in the file-objects aswell. My idea would be to add a boolean property `unstaged` which the user could check for unstaged changes.

If you like the idea, I can add the modifications to this pr. :wink:
