### PR TITLE
Use child_process spawn instead of exec

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -22,8 +22,15 @@ module.exports = Git = (git_dir, dot_git) ->
       stderr += buffer.toString 'binary'
     proc.on 'error', (err) ->
       callback err, stdout, stderr
-    proc.on 'exit', () ->
-      callback null, stdout, stderr
+    proc.on 'exit', ( code, signal ) ->
+      # Manually create a error to match previous .exec() functionality,
+      # which carries the stderr as the message
+      if code
+        err = new Error( stderr )
+        err.code = code
+        err.signal = signal
+
+      callback err, stdout, stderr
 
   # Public: Passthrough for raw git commands
   #

--- a/src/ref.coffee
+++ b/src/ref.coffee
@@ -38,7 +38,7 @@ exports.Head = class Head extends Ref
     Ref.find_all repo, "head", Head, callback
 
   @current: (repo, callback) ->
-    fs.readFile "#{repo.dot_git}/HEAD", (err, data) ->
+    fs.readFile "#{repo.dot_git}/HEAD", "utf8", (err, data) ->
       return callback err if err
 
       ref = /ref: refs\/heads\/([^\s]+)/.exec data
@@ -46,7 +46,7 @@ exports.Head = class Head extends Ref
       return callback new Error "Current branch is not a valid branch." if !ref
 
       [m, branch] = ref
-      fs.readFile "#{repo.dot_git}/refs/heads/#{branch}", (err, id) ->
-        Commit.find repo, id, (err, commit) ->
+      fs.readFile "#{repo.dot_git}/refs/heads/#{branch}", "utf8", (err, id) ->
+        Commit.find repo, id.trim(), (err, commit) ->
           return callback err if err
           return callback null, (new Head branch, commit)

--- a/src/repo.coffee
+++ b/src/repo.coffee
@@ -44,10 +44,10 @@ module.exports = class Repo
   #
   identify: (actor, callback) ->
     # git config user.email "you@example.com"
-    @git "config", {}, ["user.email", "\"#{actor.email}\""], (err) =>
+    @git "config", {}, ["user.email", "#{actor.email}"], (err) =>
       return callback err if err
       # git config user.name "Your Name"
-      @git "config", {}, ["user.name", "\"#{actor.name}\""], (err) =>
+      @git "config", {}, ["user.name", "#{actor.name}"], (err) =>
         return callback err if err
         return callback null
 
@@ -382,9 +382,9 @@ module.exports = class Repo
   commit: (message, options, callback) ->
     [options, callback] = [callback, options] if !callback
     options ?= {}
-    options = _.extend options, {m: "\"#{message}\""}
+    options = _.extend options, {m: "#{message}"}
     # add quotes around author
-    options.author = "\"#{options.author}\"" if options.author?
+    options.author = "#{options.author}" if options.author?
     @git "commit", options, callback
 
   # Public: Add files to the index.

--- a/src/status.coffee
+++ b/src/status.coffee
@@ -4,7 +4,7 @@
 # callback - Receives `(err, status)`
 #
 module.exports = S = (repo, callback) ->
-  repo.git "status --porcelain", (err, stdout, stderr) ->
+  repo.git "status", {porcelain: true}, (err, stdout, stderr) ->
     status = new Status repo
     status.parse stdout
     return callback err, status

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -1,7 +1,7 @@
 should = require 'should'
 git    = require '../src'
 Repo   = require '../src/repo'
-fs     = require "fs"
+fs     = require "fs-extra"
 {exec} = require 'child_process'
 
 describe "git", ->
@@ -23,7 +23,7 @@ describe "git", ->
       bare = repo.bare || false
       bare.should.be.false
     after (done) ->
-      exec "rm -rf #{newRepositoryDir}", done
+      fs.remove newRepositoryDir, done
 
   describe "init() bare", ->
     repo = null
@@ -38,7 +38,7 @@ describe "git", ->
       bare = repo.bare || false
       bare.should.be.true
     after (done) ->
-      exec "rm -rf #{newRepositoryDir}", done
+      fs.remove newRepositoryDir, done
 
   describe "clone()", ->
     @timeout 30000
@@ -54,4 +54,4 @@ describe "git", ->
         remotes.should.have.length 1
         done()
     after (done) ->
-      exec "rm -rf #{newRepositoryDir}", done
+      fs.remove newRepositoryDir, done


### PR DESCRIPTION
Hey @notatestuser,
I tried to implement the usage of `child_process.spawn` method instead of `child_process.exec` to avoid errors as reported in #23.

I'm opening this PR so we can discuss the changes and fix possible errors - unfortunately I'm a Windows developer, so I couldn't run successfully all tests (I'm hoping Travis will tell me what's wrong).

Thanks in advance!

Fixes #23
