### PR TITLE
enable specify git binary location along with other options in the constructor

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,7 +1,8 @@
 fs     = require 'fs'
 {exec} = require 'child_process'
 
-module.exports = Git = (git_dir, dot_git) ->
+module.exports = Git = (git_dir, dot_git, git_options) ->
+  git_options ||= {}
   dot_git ||= "#{git_dir}/.git"
 
   git = (command, options, args, callback) ->
@@ -12,7 +13,7 @@ module.exports = Git = (git_dir, dot_git) ->
     options  = options.join " "
     args    ?= []
     args     = args.join " " if args instanceof Array
-    bash     = "#{Git.bin} #{command} #{options} #{args}"
+    bash     = "#{git_options.bin || Git.bin} #{command} #{options} #{args}"
     exec bash, {cwd: git_dir}, callback
     return bash
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,8 +4,8 @@ Repo   = require './repo'
 # Public: Create a Repo from the given path.
 # 
 # Returns Repo.
-module.exports = Git = (path, bare=false) ->
-  return new Repo path, bare
+module.exports = Git = (path, bare=false, git_options={}) ->
+  return new Repo path, bare, git_options
 
 
 # Public: Initialize a git repository.

--- a/src/repo.coffee
+++ b/src/repo.coffee
@@ -11,12 +11,12 @@ Status = require './status'
 {Ref, Head} = require './ref'
 
 module.exports = class Repo
-  constructor: (@path, @bare) ->
+  constructor: (@path, @bare, @git_options) ->
     if @bare
       @dot_git = @path
     else
       @dot_git = "#{@path}/.git"
-    @git  = cmd @path, @dot_git
+    @git  = cmd @path, @dot_git, @git_options
 
 
   # Public: Get the commit identity for this repository.


### PR DESCRIPTION
Resolving this issue https://github.com/sentientwaffle/gift/issues/32

In the constructor I am passing in a git_options directory, which can specify the git binary location. Please let me know if you have any questions. Please see below for a sample use.

```
git  = require './src/'
repo = git '/Users/edaniya/git/gift', null, {bin: "/usr/bin/tmp/git"}
repo.commits "master", 1, (err, commits) ->
  console.log commits
```
