### PR TITLE
Adjusted maxBuffer sent to exec

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -13,7 +13,7 @@ module.exports = Git = (git_dir, dot_git) ->
     args    ?= []
     args     = args.join " " if args instanceof Array
     bash     = "#{Git.bin} #{command} #{options} #{args}"
-    exec bash, {cwd: git_dir}, callback
+    exec bash, {cwd: git_dir, maxBuffer: 5000*1024}, callback
     return bash
 
 


### PR DESCRIPTION
Would it be possible to adjust the `maxBuffer` sent to exec?  When using `gulp-gh-pages` I'm running into:
```
[12:20:28] [gulp-test]: Updating repository
/node_modules/gulp-gh-pages/node_modules/when/lib/decorators/unhandledRejection.js:80
		throw e;
		      ^
Error: Error: stdout maxBuffer exceeded.
```
The adjustment I made resolves this problem for me. Does increasing the `maxBuffer` have other side effects for gift?  If so would it be possible to entertain the idea of offering this as an option?

Thanks