### PR TITLE
Adjusted maxBuffer sent to exec for large repos

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -14,7 +14,7 @@ module.exports = Git = (git_dir, dot_git, git_options) ->
     args    ?= []
     args     = args.join " " if args instanceof Array
     bash     = "#{git_options.bin || Git.bin} #{command} #{options} #{args}"
-    exec bash, {cwd: git_dir, encoding:'binary'}, callback
+    exec bash, {cwd: git_dir, encoding:'binary', maxBuffer: 5000 * 1024}, callback
     return bash
 
   # Public: Passthrough for raw git commands


### PR DESCRIPTION


Would it be possible to adjust the maxBuffer sent to exec?  I'm running into:

```
[12:20:28] [gulp-test]: Updating repository
/node_modules/gulp-gh-pages/node_modules/when/lib/decorators/unhandledRejection.js:80
        throw e;
              ^
Error: Error: stdout maxBuffer exceeded.
```
The adjustment I made resolves this problem for me. Does increasing the maxBuffer have other side effects for gift? If so would it be possible to entertain the idea of offering this as an option?

Thanks
