### PR TITLE
Add a public override for the maxBuffer option

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -15,7 +15,11 @@ module.exports = Git = (git_dir, dot_git, git_options) ->
     args     = args.join " " if args instanceof Array
     encoding ?= 'utf8'
     bash     = "#{git_options.bin || Git.bin} #{command} #{options} #{args}"
-    exec bash, {cwd: git_dir, encoding: encoding, maxBuffer: 5000 * 1024}, callback
+    exec bash, {
+      cwd: git_dir,
+      encoding: encoding,
+      maxBuffer: git_options.maxBuffer || 5000 * 1024
+    }, callback
     return bash
 
   # Public: Passthrough for raw git commands

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,9 +4,12 @@ Repo   = require './repo'
 # Public: Create a Repo from the given path.
 #
 # Returns Repo.
-module.exports = Git = (path, bare=false, git_options={}) ->
-  return new Repo path, bare, git_options
+module.exports = Git = (path, bare=false, git_options={
+  maxBuffer: Git.maxBuffer
+}) -> return new Repo path, bare, git_options
 
+# Public: maxBuffer size for git commands
+Git.maxBuffer = 5000 * 1024
 
 # Public: Initialize a git repository.
 #
@@ -23,7 +26,7 @@ Git.init = (path, bare, callback) ->
   exec bash, {cwd: path}
   , (err, stdout, stderr) ->
     return callback err if err
-    return callback err, (new Repo path, bare)
+    return callback err, (new Repo path, bare, { maxBuffer: Git.maxBuffer })
 
 # Public: Clone a git repository.
 #
@@ -35,4 +38,4 @@ Git.clone = (repository, path, callback) ->
   bash = "git clone #{repository} #{path}"
   exec bash, (err, stdout, stderr) ->
     return callback err if err
-    return callback err, (new Repo path)
+    return callback err, (new Repo path, false, { maxBuffer: Git.maxBuffer })


### PR DESCRIPTION
- add maxBuffer property to index module
- allow passing of maxBuffer to the git object via git_options
- pass the index maxBuffer along with the git_options


We currently have a need to have some commands with a larger buffer, add the ability to pass this in or set a global value.