### PR TITLE
Handle HG:Extra lines in commit parsing

### DIFF
--- a/src/commit.coffee
+++ b/src/commit.coffee
@@ -89,6 +89,12 @@ module.exports = class Commit
       while /^kilnhgcopies/.test lines[0]
         lines.shift()
 
+      # if converted from mercurial gpgsig may be present with non-valid gpg lines
+      # e.g. "HG:extra rebase_source:6c01d74dd05f50ede33608fe3f1b2049d93abbda"
+      # and  "HG:rename-source hg"
+      while /^HG:/.test lines[0]
+        lines.shift()
+
       # not doing anything with this yet, but it's sometimes there
       if /^encoding/.test lines[0]
         encoding = _.last lines.shift().split(" ")


### PR DESCRIPTION
There is a chance that a commit has N number of HG: lines in a commit.

discovered in: https://github.com/mozilla/addon-sdk

This will filter those lines out so parsing still works

Example:
```
commit 4ffffb7d4b38f7d678a6a662edfdf7153ede7416
tree 34927a89a170923a3fbb9d038877f787ee804e6c
parent 1dba5fa6788ffad83fc81befecc71731558117c9
author J. Ryan Stinnett <jryans@gmail.com> 1442855058 -0500
committer J. Ryan Stinnett <jryans@gmail.com> 1442855058 -0500
HG:extra commitid:F2ItGm8ptRz
HG:extra rebase_source:b082fe4bf77e22e297e303fc601165ceff1c4cbc

    Bug 912121 - Rewrite require / import to match source tree. rs=devtools

    In a following patch, all DevTools moz.build files will use DevToolsModules to
    install JS modules at a path that corresponds directly to their source tree
    location.  Here we rewrite all require and import calls to match the new
    location that these files are installed to.
```