### PR TITLE
support shallow clone a repo on a specific branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Clone a repository:
 
     git = require 'gift'
 
-    git.clone "git@host:path/to/remote/repo.git", "path/to/local/clone/repo", depth, (err, _repo) ->
+    git.clone "git@host:path/to/remote/repo.git", "path/to/local/clone/repo", depth, branch, (err, _repo) ->
       repo = _repo
       # => #<Repo>
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -35,14 +35,20 @@ Git.init = (path, bare, callback) ->
 # depth      - The specified number of revisions of shallow clone
 # callback   - Receives `(err, repo)`.
 #
-Git.clone = (repository, path, depth = 0, callback) ->
+Git.clone = (repository, path, depth = 0, branch = null, callback) ->
+  if typeof branch is 'function'
+    callback = branch
+    branch = null
   if typeof depth is 'function'
     callback = depth
     depth = 0
-  if depth is 0 or typeof depth isnt 'number'
-    bash = "git clone \"#{repository}\" \"#{path}\""
-  else
-    bash = "git clone \"#{repository}\" \"#{path}\" --depth \"#{depth}\""
+  bash = "git clone \"#{repository}\" \"#{path}\""
+
+  if branch isnt null and typeof branch is 'string'
+    bash += " --branch \"#{branch}\""
+  if depth isnt 0 and typeof depth is 'number'
+    bash += " --depth \"#{depth}\""
+
   exec bash, (err, stdout, stderr) ->
     return callback err if err
     return callback err, (new Repo path, false, { maxBuffer: Git.maxBuffer })

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -71,3 +71,18 @@ describe "git", ->
         done()
     after (done) ->
       exec "rm -rf #{newRepositoryDir}", done
+
+  describe "clone() with depth and branch", ->
+    @timeout 30000
+    repo = null
+    newRepositoryDir = "#{__dirname}/fixtures/clone_depth_branch"
+    before (done) ->
+      git.clone "https://github.com/notatestuser/gift.git", newRepositoryDir, 1, "develop", (err, _repo) ->
+        repo = _repo
+        done err
+    it "clone a repository", (done) ->
+      repo.should.be.an.instanceof Repo
+      repo.branch "develop", (err, head) ->
+        done err
+    after (done) ->
+      exec "rm -rf #{newRepositoryDir}", done


### PR DESCRIPTION
support `shallow clone` a repo on a specific branch.
`ex) git clone <git-url> --depth 1 --branch <name>`