### PR TITLE
Upgrade npm package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "url": "https://github.com/notatestuser/gift.git"
   },
   "dependencies": {
-    "underscore": "1.x.x"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
-    "fs-extra": "^0.18.4",
-    "mocha": "^2.3.3",
-    "should": "~7.1.0",
-    "sinon": "^1.17.1"
+    "coffee-script": "^1.12.7",
+    "fs-extra": "^4.0.2",
+    "mocha": "^4.0.1",
+    "should": "^13.1.3",
+    "sinon": "^4.1.1"
   },
   "engines": {
     "node": "> 0.4.1"

--- a/test/repo.test.coffee
+++ b/test/repo.test.coffee
@@ -78,12 +78,14 @@ describe "Repo", ->
       remote = branch = ""
 
       before ->
-        sinon.stub repo, "git", (command, opts, args, callback) ->
+        sinon.stub repo, "git"
+        .callsFake (command, opts, args, callback) ->
           if command is "pull"
             remote = args[0]
             branch = args[1]
           callback? null
-        sinon.stub repo, "status", (callback) ->
+        sinon.stub repo, "status"
+        .callsFake (callback) ->
           callback? null, clean: no
 
       after ->


### PR DESCRIPTION
Most of the devDependencies were dated, ref: https://david-dm.org/notatestuser/gift?type=dev

@notatestuser maybe we should dropped end-of-life nodejs versions like v0.10 & v0.12?

